### PR TITLE
Feat: QuestionOptionButton의 Pressed 상태 디자인 적용

### DIFF
--- a/HeeBob/Presentation/Question/QuestionOptionButton.swift
+++ b/HeeBob/Presentation/Question/QuestionOptionButton.swift
@@ -9,30 +9,48 @@ import SwiftUI
 
 struct QuestionOptionButton: View {
     let title: String
-    let type: QuestionOptionButtonType
     let isDisabled: Bool
     let didTap: () -> Void
     
-    var body: some View {
-        Button {
-            didTap()
-        } label: {
-            ZStack {
-                RoundedRectangle(cornerRadius: 16)
-                    .fill(isDisabled ? Color.clear : Color.hbPrimaryLighten)
-                    .stroke(isDisabled ? Color.hbDisabled : Color.hbPrimary, style: .init(lineWidth: 3))
-                    .frame(width: 173, height: type == .half ? 160 : 144 )
-                
-                Text(title)
-                    .font(.hbSubtitle)
-                    .foregroundStyle(isDisabled ? Color.hbDisabled : Color.hbPrimary)
-            }
-        }
-
+    private var baseFillColor: Color {
+        isDisabled ? .clear : .hbPrimaryLighten
     }
     
-    enum QuestionOptionButtonType {
-        case half
-        case quarter
+    private var baseStrokeColor: Color {
+        isDisabled ? .hbDisabled : .hbPrimary
+    }
+
+    var body: some View {
+        Button(action: didTap) {
+            Text(title)
+                .font(.hbSubtitle)
+                .foregroundStyle(isDisabled ? Color.hbDisabled : Color.hbPrimary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        }
+        .buttonStyle(
+            QuestionOptionButtonStyle(
+                fillColor: baseFillColor,
+                strokeColor: baseStrokeColor
+            )
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+struct QuestionOptionButtonStyle: ButtonStyle {
+    let fillColor: Color
+    let strokeColor: Color
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .multilineTextAlignment(.center)
+            .contentShape(Rectangle()) // 터치 영역
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(configuration.isPressed ? Color.hbPrimary : fillColor)
+                    .stroke(strokeColor, lineWidth: 3)
+            )
+            .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
     }
 }

--- a/HeeBob/Presentation/Question/QuestionView.swift
+++ b/HeeBob/Presentation/Question/QuestionView.swift
@@ -38,11 +38,11 @@ struct QuestionView: View {
                     ForEach(viewModel.selectedQuestion.options.indices, id: \.self) { index in
                         QuestionOptionButton(
                             title: viewModel.selectedQuestion.options[index],
-                            type: .half,
                             isDisabled: viewModel.selectedQuestion.selectedOptionIndex != index
                         ) {
                             viewModel.selectOption(at: index)
                         }
+                        .frame(width: 173, height: 160)
                     }
                 }
                 .padding(.bottom, halfButtonsBottomPadding)
@@ -52,11 +52,11 @@ struct QuestionView: View {
                         ForEach(viewModel.selectedQuestion.options.indices[0..<2], id: \.self) { index in
                             QuestionOptionButton(
                                 title: viewModel.selectedQuestion.options[index],
-                                type: .quarter,
                                 isDisabled: viewModel.selectedQuestion.selectedOptionIndex != index
                             ) {
                                 viewModel.selectOption(at: index)
                             }
+                            .frame(width: 173, height: 144)
                         }
                     }
                     
@@ -64,11 +64,11 @@ struct QuestionView: View {
                         ForEach(viewModel.selectedQuestion.options.indices[2..<4], id: \.self) { index in
                             QuestionOptionButton(
                                 title: viewModel.selectedQuestion.options[index],
-                                type: .quarter,
                                 isDisabled: viewModel.selectedQuestion.selectedOptionIndex != index
                             ) {
                                 viewModel.selectOption(at: index)
                             }
+                            .frame(width: 173, height: 144)
                         }
                     }
                 }


### PR DESCRIPTION
> PR 제목 예시: [Issue #16] 메뉴 상세보기 뷰 구현

close #1

## *⛳️ Work Description*
- 가이드 내용은 제거해 주세요.
- 작업한 내용을 작성해 주세요.

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|ex)로그인|<img width="300" alt="" src="">|

https://github.com/user-attachments/assets/2e720b9b-068a-4958-bdbc-8514dddb312e


## *📢 To Reviewers*
-
